### PR TITLE
Try to fix dead backend

### DIFF
--- a/roles/dpr-production-deploy/tasks/main.yml
+++ b/roles/dpr-production-deploy/tasks/main.yml
@@ -91,6 +91,13 @@
     cmd: "g++ -O3 -I/usr/include/opencv4/ prederot.cpp -o prederot -L`pkg-config --libs opencv4`"
     creates: "prederot"
 
+- name: compile siderot
+  become: yes
+  shell:
+    chdir: "/srv/{{project_name}}/dcppr"
+    cmd: "g++ -O3 -I/usr/include/opencv4/ siderot.cpp -o siderot -L`pkg-config --libs opencv4`"
+    creates: "siderot"
+
 - name: create /bin folder for web
   become: yes
   file:
@@ -112,6 +119,7 @@
     - radii_check
     - derot
     - prederot
+    - siderot
 
 - name: Nginx.conf to  /etc/nginx/sites-available
   become: yes

--- a/roles/dpr-production-deploy/templates/diyrot.ini
+++ b/roles/dpr-production-deploy/templates/diyrot.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-chdir = /srv/{{ project_name }}
+chdir = /srv/{{ project_name }}/proc
 plugins = python3, syslog
 module = app:app
 logger = syslog:netdpr


### PR DESCRIPTION
librenms reports:

> ModuleNotFoundError: No module named 'app'
> unable to load app 0 (mountpoint='') (callable not found or import error)
> ** no app loaded. GAME OVER *** 

I believe this is due to `uwsgi.ini` chdir-ing into the root folder of the project, rather than the `proc/` folder where `app.py` is located.

Additionally, add the siderot binary as an ansible task.